### PR TITLE
Add GitHub Actions CI for iOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          # Use available Xcode 16 release
+          xcode-version: '16.2.0'
+      - name: Show available SDKs
+        run: xcodebuild -showsdks
+      - name: List available simulators
+        run: xcrun simctl list
+      - name: Build and run tests
+        run: |
+          xcodebuild test \
+            -project build-a-bot/build-a-bot.xcodeproj \
+            -scheme build-a-bot \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 14'

--- a/README.md
+++ b/README.md
@@ -156,10 +156,15 @@ Add usage strings to `Info.plist`:
 ---
 
 ## Testing
-- **Unit:** XCTest (services, models).  
-- **UI:** XCUITest for start/stop, permission flows.  
-- **Health/Location fakes:** inject mock services for simulator.  
-- **CI suggestion:** GitHub Actions for PR builds & unit tests; add Xcode Cloud/TestFlight once M1 stabilizes.
+- **Unit:** XCTest (services, models).
+- **UI:** XCUITest for start/stop, permission flows.
+- **Health/Location fakes:** inject mock services for simulator.
+- **CI:** GitHub Actions uses Xcode 16.2.0 to build the project and run all unit and UI tests on every PR. It prints available SDKs with `xcodebuild -showsdks`, lists simulators with `xcrun simctl list`, and targets an iPhone 14 on the latest iOS version.
+
+### Adding UI tests to CI
+1. Add tests to the `build-a-botUITests` target.
+2. Ensure the tests are part of the shared `build-a-bot` scheme in Xcode (Product → Scheme → Manage Schemes… → check **Shared**).
+3. Commit and push; the workflow in `.github/workflows/ci.yml` will pick them up automatically.
 
 ---
 


### PR DESCRIPTION
## Summary
- add macOS GitHub Actions workflow to build the app, list available simulators and SDKs, and run tests on pull requests
- document CI behavior and how to add UI tests
- specify Xcode 16.2.0 and use latest iPhone 14 simulator for compatibility

## Testing
- `xcodebuild -showsdks` *(fails: command not found)*
- `xcrun simctl list` *(fails: command not found)*
- `xcodebuild test -project build-a-bot/build-a-bot.xcodeproj -scheme build-a-bot -destination 'platform=iOS Simulator,OS=latest,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfe8567ac8333b60202c27eb7af65