### PR TITLE
Add GitHub Actions CI for iOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode 15.4
+        run: sudo xcode-select -switch /Applications/Xcode_15.4.app
+      - name: List available simulators
+        run: xcrun simctl list
+      - name: Build and test
+        run: |
+          xcodebuild test \
+            -project build-a-bot/build-a-bot.xcodeproj \
+            -scheme build-a-bot \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO

--- a/README.md
+++ b/README.md
@@ -156,10 +156,15 @@ Add usage strings to `Info.plist`:
 ---
 
 ## Testing
-- **Unit:** XCTest (services, models).  
-- **UI:** XCUITest for start/stop, permission flows.  
-- **Health/Location fakes:** inject mock services for simulator.  
-- **CI suggestion:** GitHub Actions for PR builds & unit tests; add Xcode Cloud/TestFlight once M1 stabilizes.
+- **Unit:** XCTest (services, models).
+- **UI:** XCUITest for start/stop, permission flows.
+- **Health/Location fakes:** inject mock services for simulator.
+- **CI:** GitHub Actions selects Xcode 15.4, lists available simulators, then builds the app and runs unit and UI tests on a generic iOS simulator with code signing disabled.
+
+### Adding UI tests to CI
+1. Add new `XCTestCase` files to the `build-a-botUITests` target.
+2. Commit your changes and open a pull request.
+3. The workflow automatically executes the UI tests on the simulator.
 
 ---
 


### PR DESCRIPTION
## Summary
- run iOS CI build and tests on a generic iOS Simulator with code signing disabled
- document the CI workflow and how to add UI tests

## Testing
- `xcrun simctl list` *(command not found)*
- `xcodebuild test -project build-a-bot/build-a-bot.xcodeproj -scheme build-a-bot -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfe8567ac8333b60202c27eb7af65