### PR TITLE
Add GitHub Actions CI for iOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4'
+      - name: Show SDKs
+        run: xcodebuild -showsdks
+      - name: List available simulators
+        run: xcrun simctl list
+      - name: Build and test
+        run: |
+          xcodebuild test \
+            -project build-a-bot/build-a-bot.xcodeproj \
+            -scheme build-a-bot \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 14' \
+            CODE_SIGNING_ALLOWED=NO

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ BuildABod/
 ## Setup
 
 ### Prereqs
-- Xcode 15+, iOS 16+ device/simulator.
+ - Xcode 16+, iOS 16+ device/simulator.
 - Apple Developer account (Health/Background modes).
 - Firebase project.
 
@@ -156,10 +156,15 @@ Add usage strings to `Info.plist`:
 ---
 
 ## Testing
-- **Unit:** XCTest (services, models).  
-- **UI:** XCUITest for start/stop, permission flows.  
-- **Health/Location fakes:** inject mock services for simulator.  
-- **CI suggestion:** GitHub Actions for PR builds & unit tests; add Xcode Cloud/TestFlight once M1 stabilizes.
+- **Unit:** XCTest (services, models).
+- **UI:** XCUITest for start/stop, permission flows.
+- **Health/Location fakes:** inject mock services for simulator.
+- **CI:** GitHub Actions uses `maxim-lobanov/setup-xcode` to select preinstalled Xcode 16.4, displays available SDKs and simulators, then builds the app and runs unit and UI tests on the latest iPhone 14 simulator with code signing disabled.
+
+### Adding UI tests to CI
+1. Add new `XCTestCase` files to the `build-a-botUITests` target.
+2. Commit your changes and open a pull request.
+3. The workflow automatically executes the UI tests on the simulator.
 
 ---
 


### PR DESCRIPTION
## Summary
- run iOS CI build and tests on a generic iOS simulator using preinstalled Xcode 16.4
- document the CI workflow and how to add UI tests
- switch to maxim-lobanov/setup-xcode for selecting the Xcode version

## Testing
- `xcodebuild -showsdks` *(command not found)*
- `xcrun simctl list` *(command not found)*
- `xcodebuild test -project build-a-bot/build-a-bot.xcodeproj -scheme build-a-bot -destination 'platform=iOS Simulator,OS=latest,name=iPhone 14' CODE_SIGNING_ALLOWED=NO` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfe8567ac8333b60202c27eb7af65