### PR TITLE
Store and fetch local health metrics with SwiftData

### DIFF
--- a/build-a-bot/build-a-bot/HealthMetric.swift
+++ b/build-a-bot/build-a-bot/HealthMetric.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftData
+
+@Model
+final class HealthMetric {
+    var date: Date
+    var steps: Int
+    var distance: Double
+
+    init(date: Date, steps: Int = 0, distance: Double = 0) {
+        self.date = date
+        self.steps = steps
+        self.distance = distance
+    }
+}
+

--- a/build-a-bot/build-a-bot/LocalHealthStore.swift
+++ b/build-a-bot/build-a-bot/LocalHealthStore.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftData
+
+final class LocalHealthStore {
+    func fetchMetric(for date: Date, context: ModelContext) -> HealthMetric? {
+        let startOfDay = Calendar.current.startOfDay(for: date)
+        let predicate = #Predicate<HealthMetric> { metric in
+            metric.date == startOfDay
+        }
+        let descriptor = FetchDescriptor<HealthMetric>(predicate: predicate)
+        return try? context.fetch(descriptor).first
+    }
+
+    func save(metric: HealthMetric, context: ModelContext) {
+        context.insert(metric)
+        try? context.save()
+    }
+
+    func updateMetric(_ metric: HealthMetric, context: ModelContext) {
+        // Assume metric is already managed by the context; simply save changes
+        try? context.save()
+    }
+}
+

--- a/build-a-bot/build-a-bot/StepCountView.swift
+++ b/build-a-bot/build-a-bot/StepCountView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
+import SwiftData
 
 struct StepCountView: View {
     @State private var stepCount: Double = 0
+    @Environment(\.modelContext) private var modelContext
+    private let localStore = LocalHealthStore()
 
     var body: some View {
         VStack(spacing: 20) {
@@ -12,8 +15,19 @@ struct StepCountView: View {
                 .bold()
         }
         .onAppear {
-            HealthKitManager.shared.fetchTodayStepCount { count, _ in
-                stepCount = count
+            let today = Date()
+            if let metric = localStore.fetchMetric(for: today, context: modelContext) {
+                stepCount = Double(metric.steps)
+            } else {
+                HealthKitManager.shared.fetchTodayStepCount { count, _ in
+                    stepCount = count
+                    let metric = HealthMetric(
+                        date: Calendar.current.startOfDay(for: today),
+                        steps: Int(count),
+                        distance: 0
+                    )
+                    localStore.save(metric: metric, context: modelContext)
+                }
             }
         }
         .padding()

--- a/build-a-bot/build-a-bot/build_a_botApp.swift
+++ b/build-a-bot/build-a-bot/build_a_botApp.swift
@@ -20,6 +20,6 @@ struct build_a_botApp: App {
             ContentView()
         }
         // Provide SwiftData context to the whole view tree
-        .modelContainer(for: [Item.self])
+        .modelContainer(for: [Item.self, HealthMetric.self])
     }
 }


### PR DESCRIPTION
## Summary
- add `HealthMetric` SwiftData model storing date, steps and distance
- persist `HealthMetric` via `.modelContainer` in the app
- create `LocalHealthStore` for fetching and saving metrics
- load step count from local storage in `StepCountView` and fall back to `HealthKit`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ab266b188333af89c98e06d290a5