### PR TITLE
Seed defaults for offline step data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _A simple, offline-first walking & running tracker with smart route goals and pr
 - [Notifications (“Beat-Your-Best”)](#notifications-beat-your-best)
 - [Roadmap (high-level)](#roadmap-high-level)
 - [Testing](#testing)
+- [Testing offline data](#testing-offline-data)
 - [Dev tips](#dev-tips)
 - [Contributing](#contributing)
 - [License](#license)
@@ -184,6 +185,13 @@ Add usage strings to `Info.plist`:
 1. Add new `XCTestCase` files to the `build-a-botUITests` target.
 2. Commit your changes and open a pull request.
 3. The workflow automatically executes the UI tests on the simulator.
+
+### Testing offline data
+The app bundles `Resources/DefaultHealthMetrics.json` containing sample daily
+step and distance values. Unit tests and SwiftUI previews can seed an in-memory
+`ModelContainer` with this fixture by calling
+`LocalHealthStore().loadDefaultMetricsIfNeeded(context:)`, allowing the UI to
+run without HealthKit access.
 
 ---
 

--- a/build-a-bot/build-a-bot/LocalHealthStore.swift
+++ b/build-a-bot/build-a-bot/LocalHealthStore.swift
@@ -20,5 +20,48 @@ final class LocalHealthStore {
         // Assume metric is already managed by the context; simply save changes
         try? context.save()
     }
+
+    /// Populate the store with bundled defaults when appropriate.
+    /// - Parameters:
+    ///   - context: The model context to insert metrics into.
+    ///
+    /// Loads data when the store is empty or when running in DEBUG / preview
+    /// modes so the UI can function without HealthKit.
+    func loadDefaultMetricsIfNeeded(context: ModelContext) {
+        let fetch = FetchDescriptor<HealthMetric>()
+        let existing = (try? context.fetch(fetch)) ?? []
+
+        #if DEBUG
+        let shouldLoad = existing.isEmpty || ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+        #else
+        let shouldLoad = existing.isEmpty
+        #endif
+
+        if shouldLoad {
+            loadDefaultMetrics(context: context)
+        }
+    }
+
+    /// Loads metrics from `DefaultHealthMetrics.json` in the app bundle.
+    private func loadDefaultMetrics(context: ModelContext) {
+        guard let url = Bundle.main.url(forResource: "DefaultHealthMetrics", withExtension: "json"),
+              let data = try? Data(contentsOf: url) else { return }
+
+        struct DefaultMetric: Decodable { let steps: Int; let distance: Double }
+
+        do {
+            let defaults = try JSONDecoder().decode([DefaultMetric].self, from: data)
+            for (index, metric) in defaults.enumerated() {
+                if let date = Calendar.current.date(byAdding: .day, value: -index, to: Date()) {
+                    let start = Calendar.current.startOfDay(for: date)
+                    let model = HealthMetric(date: start, steps: metric.steps, distance: metric.distance)
+                    context.insert(model)
+                }
+            }
+            try? context.save()
+        } catch {
+            print("Failed to decode DefaultHealthMetrics.json: \(error)")
+        }
+    }
 }
 

--- a/build-a-bot/build-a-bot/Resources/DefaultHealthMetrics.json
+++ b/build-a-bot/build-a-bot/Resources/DefaultHealthMetrics.json
@@ -1,0 +1,9 @@
+[
+  { "steps": 7500, "distance": 5.2 },
+  { "steps": 8200, "distance": 5.9 },
+  { "steps": 10200, "distance": 7.2 },
+  { "steps": 6600, "distance": 4.8 },
+  { "steps": 9000, "distance": 6.4 },
+  { "steps": 12000, "distance": 8.5 },
+  { "steps": 5000, "distance": 3.5 }
+]

--- a/build-a-bot/build-a-bot/StepCountView.swift
+++ b/build-a-bot/build-a-bot/StepCountView.swift
@@ -15,6 +15,8 @@ struct StepCountView: View {
                 .bold()
         }
         .onAppear {
+            localStore.loadDefaultMetricsIfNeeded(context: modelContext)
+
             let today = Date()
             if let metric = localStore.fetchMetric(for: today, context: modelContext) {
                 stepCount = Double(metric.steps)
@@ -31,5 +33,14 @@ struct StepCountView: View {
 }
 
 #Preview {
-    StepCountView()
+    do {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: HealthMetric.self, configurations: config)
+        let store = LocalHealthStore()
+        store.loadDefaultMetricsIfNeeded(context: container.mainContext)
+        return StepCountView()
+            .modelContainer(container)
+    } catch {
+        return StepCountView()
+    }
 }

--- a/build-a-bot/build-a-botTests/build_a_botTests.swift
+++ b/build-a-bot/build-a-botTests/build_a_botTests.swift
@@ -34,4 +34,22 @@ struct build_a_botTests {
         #expect(updated?.steps == 200)
     }
 
+    @MainActor
+    @Test func loadsDefaultMetricsWhenStoreEmpty() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: HealthMetric.self, configurations: config)
+        let context = container.mainContext
+        let store = LocalHealthStore()
+
+        // Should insert bundled metrics for today and prior days
+        store.loadDefaultMetricsIfNeeded(context: context)
+
+        // Ensure StepCountView can render with the seeded data
+        _ = StepCountView().modelContainer(container)
+
+        let metric = store.fetchMetric(for: Date(), context: context)
+        #expect(metric != nil)
+        #expect((metric?.steps ?? 0) > 0)
+    }
+
 }


### PR DESCRIPTION
## Summary
- add DefaultHealthMetrics fixture with sample steps and distance
- load bundled defaults through LocalHealthStore for previews/tests
- document how to run UI without HealthKit using offline data

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d381d76c833398f48926a4f6c2eb