### PR TITLE
Add bottom TabView navigation

### DIFF
--- a/build-a-bot/build-a-bot/ContentView.swift
+++ b/build-a-bot/build-a-bot/ContentView.swift
@@ -1,36 +1,25 @@
 import SwiftUI
-#if canImport(FirebaseCore)
-import FirebaseCore
-#endif
-#if canImport(FirebaseFirestore)
-import FirebaseFirestore
-#endif
 
 struct ContentView: View {
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 16) {
-                Button("Check Firebase configured") {
-                    print("Firebase configured:", FirebaseApp.app() != nil)
+        TabView {
+            DashboardView()
+                .tabItem {
+                    Label("Dashboard", systemImage: "house")
                 }
-
-                #if canImport(FirebaseFirestore)
-                Button("Test Firestore write") {
-                    Firestore.firestore().collection("debug")
-                        .addDocument(data: ["hello":"world","ts":Date()]) { err in
-                            print(err == nil ? "Firestore write OK" : "Firestore error: \(err!)")
-                        }
+            GoalsView()
+                .tabItem {
+                    Label("Goals", systemImage: "flag")
                 }
-                #endif
-
-                NavigationLink("Show Today's Steps") {
-                    StepCountView()
+            FriendsView()
+                .tabItem {
+                    Label("Friends", systemImage: "person.2")
                 }
-            }
-            .buttonStyle(.bordered)
-            .padding()
-            .navigationTitle("Build-A-Bod")
-            .onAppear { print("ContentView appeared") }
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person.crop.circle")
+                }
         }
     }
 }
+

--- a/build-a-bot/build-a-bot/DashboardView.swift
+++ b/build-a-bot/build-a-bot/DashboardView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+#if canImport(FirebaseCore)
+import FirebaseCore
+#endif
+#if canImport(FirebaseFirestore)
+import FirebaseFirestore
+#endif
+
+struct DashboardView: View {
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                Button("Check Firebase configured") {
+                    print("Firebase configured:", FirebaseApp.app() != nil)
+                }
+
+                #if canImport(FirebaseFirestore)
+                Button("Test Firestore write") {
+                    Firestore.firestore().collection("debug")
+                        .addDocument(data: ["hello":"world","ts":Date()]) { err in
+                            print(err == nil ? "Firestore write OK" : "Firestore error: \(err!)")
+                        }
+                }
+                #endif
+
+                NavigationLink("Show Today's Steps") {
+                    StepCountView()
+                }
+            }
+            .buttonStyle(.bordered)
+            .padding()
+            .navigationTitle("Build-A-Bod")
+            .onAppear { print("DashboardView appeared") }
+        }
+    }
+}
+

--- a/build-a-bot/build-a-bot/FriendsView.swift
+++ b/build-a-bot/build-a-bot/FriendsView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct FriendsView: View {
+    var body: some View {
+        NavigationStack {
+            Text("Friends View")
+                .navigationTitle("Friends")
+        }
+    }
+}
+

--- a/build-a-bot/build-a-bot/GoalsView.swift
+++ b/build-a-bot/build-a-bot/GoalsView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct GoalsView: View {
+    var body: some View {
+        NavigationStack {
+            Text("Goals View")
+                .navigationTitle("Goals")
+        }
+    }
+}
+

--- a/build-a-bot/build-a-bot/ProfileView.swift
+++ b/build-a-bot/build-a-bot/ProfileView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        NavigationStack {
+            Text("Profile View")
+                .navigationTitle("Profile")
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Replace root ContentView with a TabView containing Dashboard, Goals, Friends, and Profile tabs
- Move existing home screen functionality into new DashboardView
- Add placeholder GoalsView, FriendsView, and ProfileView

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e8787e048333816f145ebf39ce66