### PR TITLE
Toggle StepWidget between steps and distance

### DIFF
--- a/build-a-bot/build-a-bot/HealthKitManager.swift
+++ b/build-a-bot/build-a-bot/HealthKitManager.swift
@@ -11,13 +11,14 @@ class HealthKitManager {
     func requestAuthorization(completion: @escaping (Bool, Error?) -> Void) {
         guard
             let stepCount = HKObjectType.quantityType(forIdentifier: .stepCount),
-            let distance = HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)
+            let distance = HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning),
+            let stride = HKObjectType.quantityType(forIdentifier: .walkingStepLength)
         else {
             completion(false, NSError(domain: "HealthKit", code: 1, userInfo: [NSLocalizedDescriptionKey: "Required types unavailable"]))
             return
         }
 
-        let typesToRead: Set<HKObjectType> = [stepCount, distance]
+        let typesToRead: Set<HKObjectType> = [stepCount, distance, stride]
 
         healthStore.requestAuthorization(toShare: nil, read: typesToRead) { success, error in
             completion(success, error)
@@ -51,6 +52,57 @@ class HealthKitManager {
         healthStore.execute(query)
     }
 
+    /// Fetch the walking/running distance for today.
+    func fetchTodayDistance(context: ModelContext, completion: @escaping (HealthMetric?, Error?) -> Void) {
+        guard let distanceType = HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning) else {
+            completion(nil, NSError(domain: "HealthKit", code: 3, userInfo: [NSLocalizedDescriptionKey: "Distance type unavailable"]))
+            return
+        }
+
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: Date(), options: .strictStartDate)
+
+        let query = HKStatisticsQuery(quantityType: distanceType, quantitySamplePredicate: predicate, options: .cumulativeSum) { _, result, error in
+            var metric: HealthMetric?
+            if let quantity = result?.sumQuantity() {
+                let distance = quantity.doubleValue(for: HKUnit.meter())
+                if distance > 0 {
+                    metric = self.upsertMetric(distance: distance, context: context)
+                }
+            }
+
+            DispatchQueue.main.async {
+                completion(metric, error)
+            }
+        }
+
+        healthStore.execute(query)
+    }
+
+    /// Fetch the average stride length for today.
+    func fetchAverageStrideLength(completion: @escaping (Double?, Error?) -> Void) {
+        guard let type = HKObjectType.quantityType(forIdentifier: .walkingStepLength) else {
+            completion(nil, NSError(domain: "HealthKit", code: 4, userInfo: [NSLocalizedDescriptionKey: "Stride length type unavailable"]))
+            return
+        }
+
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: Date(), options: .strictStartDate)
+
+        let query = HKStatisticsQuery(quantityType: type, quantitySamplePredicate: predicate, options: .discreteAverage) { _, result, error in
+            var length: Double?
+            if let quantity = result?.averageQuantity() {
+                length = quantity.doubleValue(for: HKUnit.meter())
+            }
+
+            DispatchQueue.main.async {
+                completion(length, error)
+            }
+        }
+
+        healthStore.execute(query)
+    }
+
     /// Update or create today's metric with the provided step count.
     func upsertMetric(steps: Double, context: ModelContext) -> HealthMetric {
         let localStore = LocalHealthStore()
@@ -61,6 +113,21 @@ class HealthKitManager {
             return existing
         } else {
             let metric = HealthMetric(date: startOfDay, steps: Int(steps))
+            localStore.save(metric: metric, context: context)
+            return metric
+        }
+    }
+
+    /// Update or create today's metric with the provided distance.
+    func upsertMetric(distance: Double, context: ModelContext) -> HealthMetric {
+        let localStore = LocalHealthStore()
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        if let existing = localStore.fetchMetric(for: startOfDay, context: context) {
+            existing.distance = distance
+            localStore.updateMetric(existing, context: context)
+            return existing
+        } else {
+            let metric = HealthMetric(date: startOfDay, distance: distance)
             localStore.save(metric: metric, context: context)
             return metric
         }

--- a/build-a-bot/build-a-bot/StepWidget.swift
+++ b/build-a-bot/build-a-bot/StepWidget.swift
@@ -3,17 +3,34 @@ import SwiftData
 
 struct StepWidget: View {
     @State private var stepCount: Double = 0
+    @State private var distance: Double = 0
+    @State private var showingSteps = true
     @Environment(\.modelContext) private var modelContext
     private let localStore = LocalHealthStore()
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 2) {
-            Text("\(Int(stepCount))")
-                .font(.largeTitle)
-                .bold()
-            Text("steps")
-                .font(.caption)
-                .baselineOffset(-4)
+            if showingSteps {
+                Text("\(Int(stepCount))")
+                    .font(.largeTitle)
+                    .bold()
+                Text("steps")
+                    .font(.caption)
+                    .baselineOffset(-4)
+            } else {
+                Text(formatDistance(distance))
+                    .font(.largeTitle)
+                    .bold()
+                Text(distanceUnitLabel())
+                    .font(.caption)
+                    .baselineOffset(-4)
+            }
+        }
+        .onTapGesture {
+            showingSteps.toggle()
+            if !showingSteps {
+                fetchDistanceIfNeeded()
+            }
         }
         .onAppear {
             localStore.loadDefaultMetricsIfNeeded(context: modelContext)
@@ -21,14 +38,46 @@ struct StepWidget: View {
             let today = Date()
             if let metric = localStore.fetchMetric(for: today, context: modelContext) {
                 stepCount = Double(metric.steps)
+                distance = metric.distance
             }
 
             HealthKitManager.shared.fetchTodayStepCount(context: modelContext) { metric, _ in
                 if let metric = metric {
                     stepCount = Double(metric.steps)
+                    distance = metric.distance
                 }
             }
         }
+    }
+
+    private func fetchDistanceIfNeeded() {
+        guard distance == 0 else { return }
+
+        HealthKitManager.shared.fetchTodayDistance(context: modelContext) { metric, _ in
+            if let metric = metric, metric.distance > 0 {
+                distance = metric.distance
+            } else {
+                HealthKitManager.shared.fetchAverageStrideLength { stride, _ in
+                    guard let stride = stride, stepCount > 0 else { return }
+                    let computed = stepCount * stride
+                    distance = computed
+                    HealthKitManager.shared.upsertMetric(distance: computed, context: modelContext)
+                }
+            }
+        }
+    }
+
+    private func formatDistance(_ meters: Double) -> String {
+        let usesMetric = Locale.current.usesMetricSystem
+        let value = usesMetric ? meters / 1000 : meters / 1609.34
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value)) ?? "0"
+    }
+
+    private func distanceUnitLabel() -> String {
+        Locale.current.usesMetricSystem ? "km" : "mi"
     }
 }
 


### PR DESCRIPTION
## Summary
- add ability to switch StepWidget between showing steps and distance
- fetch and cache walking distance or stride length when needed
- extend HealthKitManager with distance and stride length queries

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f5687b18833395dc2783ad428067